### PR TITLE
fast_mode起動設定を更新する

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -6,8 +6,8 @@ model_reasoning_effort = "xhigh"
 personality = "pragmatic"
 
 [features]
-codex_hooks = true
-fast_mode = true
+hooks = true
+fast_mode = false
 multi_agent = true
 shell_snapshot = true
 shell_tool = true

--- a/config/wezterm/keybindings.lua
+++ b/config/wezterm/keybindings.lua
@@ -351,7 +351,7 @@ local keys = {
         direction = 'Right',
         size = 0.8,
         cwd = cwd,
-        args = { SHELL, '-lic', 'codex' },
+        args = { SHELL, '-lic', 'codex --config features.fast_mode=false' },
       }
       local wide_pane = second_pane:split {
         direction = 'Right',
@@ -370,7 +370,7 @@ local keys = {
         size = 0.4,
         cwd = cwd,
       }
-      pane:send_text('codex --enable fast_mode\n')
+      pane:send_text('codex --config features.fast_mode=true --config \'service_tier="fast"\'\n')
       pane:activate()
     end),
   },


### PR DESCRIPTION
## 概要
- .codex/config.toml で hooks を有効化し、デフォルトの fast_mode を false に変更
- WezTerm の LEADER+t で左端を fast service tier、左中を normal fast_mode=false で起動

## テスト計画
- [x] luac -p config/wezterm/keybindings.lua
- [x] git diff --check
- [x] rg --glob '!**/*.png' -n -- "--enable fast_mode|features\.fast_mode|service_tier" config/wezterm cheatsheet