### PR TITLE
WezTermにタブ整理キーバインドを追加しflake.lockを更新

### DIFF
--- a/config/wezterm/keybindings.lua
+++ b/config/wezterm/keybindings.lua
@@ -204,6 +204,33 @@ local function create_grid_layout_with_command(columns, rows, command, should_sk
   end)
 end
 
+-- 現在アクティブなタブ以外をすべて閉じる
+local function close_inactive_tabs()
+  return wezterm.action_callback(function(window, pane)
+    local mux_window = window:mux_window()
+    local active_tab = mux_window:active_tab()
+    if not active_tab then return end
+
+    local active_tab_id = active_tab:tab_id()
+    local tabs_to_close = {}
+    for _, tab in ipairs(mux_window:tabs()) do
+      if tab:tab_id() ~= active_tab_id then
+        table.insert(tabs_to_close, tab)
+      end
+    end
+
+    for _, tab in ipairs(tabs_to_close) do
+      local target_pane = tab:active_pane()
+      if target_pane then
+        tab:activate()
+        window:perform_action(act.CloseCurrentTab { confirm = false }, target_pane)
+      end
+    end
+
+    active_tab:activate()
+  end)
+end
+
 ---------------------------------------------------------------
 -- 通常キーバインド
 ---------------------------------------------------------------
@@ -222,6 +249,7 @@ local keys = {
   { key = 'Tab',   mods = 'CTRL|SHIFT',  action = act.ActivateTabRelative(-1) },            -- 前のタブ
   { key = 't',     mods = 'SUPER',       action = act { SpawnTab = 'CurrentPaneDomain' } }, -- 新しいタブ
   { key = 'w',     mods = 'SUPER',       action = act.CloseCurrentTab { confirm = true } }, -- タブを閉じる
+  { key = 'W',     mods = 'SUPER|SHIFT', action = close_inactive_tabs() },                  -- アクティブ以外のタブを閉じる
   { key = 'e',     mods = 'SUPER',       action = act.ShowTabNavigator },                   -- タブ一覧
 
   -- === ペイン分割 ===

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779678629,
-        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
+        "lastModified": 1781009359,
+        "narHash": "sha256-w/mZkRscTatf8NWyUstli8ROzM/eopxZzi0WRjoeYkU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
+        "rev": "c58ead12efcac436afffa93a22099a5595eb4157",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779593580,
-        "narHash": "sha256-le3WvQyzAQjBZnb7q2c8C5Fk2c9LgN/Oq+b0KiD4fM4=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d849bb215dcdf71bce3e686839ccdb4219e84b2f",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要
- WezTerm に SUPER|SHIFT|W で現在アクティブなタブ以外をすべて閉じる `close_inactive_tabs` を追加
- home-manager / nix-darwin / nixpkgs を最新に更新（flake.lock）

## テスト計画
- [ ] WezTerm で SUPER|SHIFT|W を押すと、アクティブなタブだけ残して他のタブが閉じる
- [ ] `nix flake check` / ビルドが通る