### PR TITLE
Claude sandbox の許可ドメインに *.github.com を追加

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -215,6 +215,5 @@
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "editMode": "vim",
-  "model": "claude-sonnet-4-6"
+  "editMode": "vim"
 }

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "awsAuthRefresh": "aws login",
-  "model": "claude-opus-4-6[1m]",
   "env": {
     "DISABLE_COST_WARNINGS": "0",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
@@ -216,5 +215,6 @@
   "remoteControlAtStartup": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "editMode": "vim"
+  "editMode": "vim",
+  "model": "claude-sonnet-4-6"
 }

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -158,6 +158,7 @@
     "network": {
       "allowedDomains": [
         "github.com",
+        "*.github.com",
         "*.githubusercontent.com",
         "*.npmjs.org",
         "registry.npmjs.org",


### PR DESCRIPTION
## 概要
- サンドボックス内から `api.github.com` などの github.com サブドメインへ接続できるよう、`sandbox.network.allowedDomains` に `*.github.com` を追加
- apex の `github.com` は完全一致のため既存エントリを残置

## テスト計画
- [ ] サンドボックス有効状態で github.com サブドメイン（例: api.github.com）への接続が許可されることを確認
- [ ] `gh` コマンド（excludedCommands 対象）が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)