### PR TITLE
Claude Code 設定を更新: モデル・プラグイン・sandbox ドメイン

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -69,6 +69,7 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "claude-opus-4-6[1m]",
   "enableAllProjectMcpServers": true,
   "hooks": {
     "Stop": [
@@ -118,7 +119,8 @@
     "claude-md-management@claude-plugins-official": true,
     "torico-agent-skills@0maru-private-agent-skills": true,
     "pyright-lsp@claude-plugins-official": true,
-    "lua-lsp@claude-plugins-official": true
+    "lua-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "0maru-private-agent-skills": {
@@ -203,7 +205,6 @@
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "xhigh",
-  "fastMode": false,
   "autoMemoryEnabled": false,
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,


### PR DESCRIPTION
## 概要
- デフォルトモデルを Opus 4.6 (1M) に変更
- typescript-lsp プラグインを有効化、不要な fastMode 設定を削除
- Claude sandbox の許可ドメインに *.github.com を追加

## テスト計画
- [ ] Claude Code が正常に起動し、設定が反映されることを確認